### PR TITLE
Different consumer reuse one conn take wrong jobs.

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -71,10 +71,7 @@ func (c *Conn) cmd(t *Tube, ts *TubeSet, body []byte, op string, args ...interfa
 		c.c.W.Write(body)
 		c.c.W.Write(crnl)
 	}
-	err = c.ignoreWatchedTubes(ts)
-	if err != nil {
-		return req{}, err
-	}
+	c.resetTubes(ts)
 	err = c.c.W.Flush()
 	if err != nil {
 		return req{}, ConnError{c, op, err}
@@ -113,15 +110,15 @@ func (c *Conn) adjustTubes(t *Tube, ts *TubeSet) error {
 	return nil
 }
 
-func (c *Conn) ignoreWatchedTubes(ts *TubeSet) error {
+func (c *Conn) resetTubes(ts *TubeSet) {
 	if ts != nil {
+		c.printLine("watch", "default")
 		for s := range c.watched {
-			if !ts.Name[s] {
-				c.printLine("ignore", s)
-			}
+			c.printLine("ignore", s)
 		}
+		c.watched = make(map[string]bool)
+		c.watched["default"] = true
 	}
-	return nil
 }
 
 // does not flush

--- a/conn.go
+++ b/conn.go
@@ -71,6 +71,10 @@ func (c *Conn) cmd(t *Tube, ts *TubeSet, body []byte, op string, args ...interfa
 		c.c.W.Write(body)
 		c.c.W.Write(crnl)
 	}
+	err = c.ignoreWatchedTubes(ts)
+	if err != nil {
+		return req{}, err
+	}
 	err = c.c.W.Flush()
 	if err != nil {
 		return req{}, ConnError{c, op, err}
@@ -104,6 +108,17 @@ func (c *Conn) adjustTubes(t *Tube, ts *TubeSet) error {
 		c.watched = make(map[string]bool)
 		for s := range ts.Name {
 			c.watched[s] = true
+		}
+	}
+	return nil
+}
+
+func (c *Conn) ignoreWatchedTubes(ts *TubeSet) error {
+	if ts != nil {
+		for s := range c.watched {
+			if !ts.Name[s] {
+				c.printLine("ignore", s)
+			}
 		}
 	}
 	return nil

--- a/example_test.go
+++ b/example_test.go
@@ -48,6 +48,7 @@ func Example_putOtherTube() {
 
 func Example_reuse_socket_connection() {
 
+	// Put two data: data1, data2 into mytube1.
 	master, err := beanstalk.Dial("tcp", "127.0.0.1:11300")
 	if err != nil {
 		panic(err)
@@ -63,8 +64,10 @@ func Example_reuse_socket_connection() {
 	}
 	fmt.Printf("Put two data into mytube1\n")
 
+	// Create socket connection will be reused.
 	reusedConn, _ := net.Dial("tcp", "127.0.0.1:11300")
 
+	// Consume first data1 from mytube1 and success delete it.
 	worker1Bq := beanstalk.NewConn(reusedConn)
 	worker1Bq.Tube.Name = "mytube1"
 	worker1Bq.TubeSet = *beanstalk.NewTubeSet(worker1Bq, "mytube1")
@@ -78,6 +81,8 @@ func Example_reuse_socket_connection() {
 		panic(err)
 	}
 
+	// Reuse previous connection, and try to consume empty tube --- mytube2
+	// We hope this will get nothing...but we found it will consume mytube1 data
 	worker2Bq := beanstalk.NewConn(reusedConn)
 	worker2Bq.Tube.Name = "mytube2"
 	worker2Bq.TubeSet = *beanstalk.NewTubeSet(worker2Bq, "mytube2")

--- a/example_test.go
+++ b/example_test.go
@@ -3,9 +3,9 @@ package beanstalk_test
 import (
 	"fmt"
 	"github.com/kr/beanstalk"
-	"time"
 	"net"
 	"testing"
+	"time"
 )
 
 var conn, _ = beanstalk.Dial("tcp", "127.0.0.1:11300")
@@ -44,60 +44,4 @@ func Example_putOtherTube() {
 		panic(err)
 	}
 	fmt.Println("job", id)
-}
-
-func Example_reuse_socket_connection() {
-
-	// Put two data: data1, data2 into mytube1.
-	master, err := beanstalk.Dial("tcp", "127.0.0.1:11300")
-	if err != nil {
-		panic(err)
-	}
-	master.Tube.Name = "mytube1"
-	_, err = master.Put([]byte("data1"), 1, 0, 5 * time.Minute)
-	if err != nil {
-		panic(err)
-	}
-	_, err = master.Put([]byte("data2"), 1, 0, 5 * time.Minute)
-	if err != nil {
-		panic(err)
-	}
-	fmt.Printf("Put two data into mytube1\n")
-
-	// Create socket connection will be reused.
-	reusedConn, _ := net.Dial("tcp", "127.0.0.1:11300")
-
-	// Consume first data1 from mytube1 and success delete it.
-	worker1Bq := beanstalk.NewConn(reusedConn)
-	worker1Bq.Tube.Name = "mytube1"
-	worker1Bq.TubeSet = *beanstalk.NewTubeSet(worker1Bq, "mytube1")
-	id, data, err := worker1Bq.Reserve(5 * time.Second)
-	if err != nil {
-		panic(err)
-	}
-	fmt.Printf("Consume mytube1 will get 'data1', real got is %s\n", string(data))
-	err = worker1Bq.Delete(id)
-	if err != nil {
-		panic(err)
-	}
-
-	// Reuse previous connection, and try to consume empty tube --- mytube2
-	// We hope this will get nothing...but we found it will consume mytube1 data
-	worker2Bq := beanstalk.NewConn(reusedConn)
-	worker2Bq.Tube.Name = "mytube2"
-	worker2Bq.TubeSet = *beanstalk.NewTubeSet(worker2Bq, "mytube2")
-	id, data, err = worker2Bq.Reserve(5 * time.Second)
-	if err != nil {
-		panic(err)
-	}
-	fmt.Printf("Consume mytube2 should take nothing(mytube2 is empty), but we got %s", string(data))
-	err = worker1Bq.Delete(id)
-	if err != nil {
-		panic(err)
-	}
-
-}
-
-func TestIt(t *testing.T) {
-	Example_reuse_socket_connection()
 }

--- a/example_test.go
+++ b/example_test.go
@@ -3,8 +3,6 @@ package beanstalk_test
 import (
 	"fmt"
 	"github.com/kr/beanstalk"
-	"net"
-	"testing"
 	"time"
 )
 

--- a/example_test.go
+++ b/example_test.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"github.com/kr/beanstalk"
 	"time"
+	"net"
+	"testing"
 )
 
 var conn, _ = beanstalk.Dial("tcp", "127.0.0.1:11300")
@@ -42,4 +44,55 @@ func Example_putOtherTube() {
 		panic(err)
 	}
 	fmt.Println("job", id)
+}
+
+func Example_reuse_socket_connection() {
+
+	master, err := beanstalk.Dial("tcp", "127.0.0.1:11300")
+	if err != nil {
+		panic(err)
+	}
+	master.Tube.Name = "mytube1"
+	_, err = master.Put([]byte("data1"), 1, 0, 5 * time.Minute)
+	if err != nil {
+		panic(err)
+	}
+	_, err = master.Put([]byte("data2"), 1, 0, 5 * time.Minute)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("Put two data into mytube1\n")
+
+	reusedConn, _ := net.Dial("tcp", "127.0.0.1:11300")
+
+	worker1Bq := beanstalk.NewConn(reusedConn)
+	worker1Bq.Tube.Name = "mytube1"
+	worker1Bq.TubeSet = *beanstalk.NewTubeSet(worker1Bq, "mytube1")
+	id, data, err := worker1Bq.Reserve(5 * time.Second)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("Consume mytube1 will get 'data1', real got is %s\n", string(data))
+	err = worker1Bq.Delete(id)
+	if err != nil {
+		panic(err)
+	}
+
+	worker2Bq := beanstalk.NewConn(reusedConn)
+	worker2Bq.Tube.Name = "mytube2"
+	worker2Bq.TubeSet = *beanstalk.NewTubeSet(worker2Bq, "mytube2")
+	id, data, err = worker2Bq.Reserve(5 * time.Second)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("Consume mytube2 should take nothing(mytube2 is empty), but we got %s", string(data))
+	err = worker1Bq.Delete(id)
+	if err != nil {
+		panic(err)
+	}
+
+}
+
+func TestIt(t *testing.T) {
+	Example_reuse_socket_connection()
 }


### PR DESCRIPTION
### Problem summary

Different consumer reuse one socket connection with constructor:

```
func NewConn(conn io.ReadWriteCloser) *Conn
```

will reserve jobs that current consumer NOT wanted.
### Problem Version

latest
### Reproduce code

Please see this git:  https://gist.github.com/lysu/3f7e9687132bc46d3222
### How this PR fix problem

Add a `Reset Watch tube` stage after cmd executed.

Because beanstalkd has limit that conn must have one watched tube (https://github.com/kr/beanstalkd/blob/5fce2d1e14b61b0ffcb5d67f85f35792f8542d60/prot.c#L1565)

So, we the target we reset to will be a connect watch `default` tube like a new connection.
### Others
##### why we want to reuse socket conn

we have a common socket pool,  it's more easy to reuse that code ^ ^

although reuse `beanstalk.Conn` also can resolve this problem.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kr/beanstalk/16)
<!-- Reviewable:end -->
