### PR TITLE
feat(conn): Add kick-job support

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -186,6 +186,17 @@ func (c *Conn) Bury(id uint64, pri uint32) error {
 	return err
 }
 
+// KickJob places the given job to the ready queue of the same tube where it currently belongs
+// when the given job id exists and is in a buried or delayed state.
+func (c *Conn) KickJob(id uint64) error {
+	r, err := c.cmd(nil, nil, nil, "kick-job", id)
+	if err != nil {
+		return err
+	}
+	_, err = c.readResp(r, false, "KICKED")
+	return err
+}
+
 // Touch resets the reservation timer for the given job.
 // It is an error if the job isn't currently reserved by c.
 // See the documentation of Reserve for more details.

--- a/conn_test.go
+++ b/conn_test.go
@@ -107,6 +107,18 @@ func TestBury(t *testing.T) {
 	}
 }
 
+func TestTubeKickJob(t *testing.T) {
+	c := NewConn(mock("kick-job 3\r\n", "KICKED\r\n"))
+
+	err := c.KickJob(3)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err = c.Close(); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestDelete(t *testing.T) {
 	c := NewConn(mock("delete 1\r\n", "DELETED\r\n"))
 


### PR DESCRIPTION
Hi,

we need use kick-job to kick the job identified by special id, so add this to go client~
- Add `KickJob` to `beanstalk.Conn`
- Add KickJob test case

just as kick-job in document https://github.com/kr/beanstalkd/blob/d2922bd4ac2ad9047d081f1b044db4a2314bcf82/doc/protocol.txt

thank you~

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kr/beanstalk/19)
<!-- Reviewable:end -->
