### PR TITLE
Fix indefinite client hang after connection reset

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -59,6 +59,7 @@ func (c *Conn) Close() error {
 func (c *Conn) cmd(t *Tube, ts *TubeSet, body []byte, op string, args ...interface{}) (req, error) {
 	r := req{c.c.Next(), op}
 	c.c.StartRequest(r.id)
+	defer c.c.EndRequest(r.id)
 	err := c.adjustTubes(t, ts)
 	if err != nil {
 		return req{}, err
@@ -75,7 +76,6 @@ func (c *Conn) cmd(t *Tube, ts *TubeSet, body []byte, op string, args ...interfa
 	if err != nil {
 		return req{}, ConnError{c, op, err}
 	}
-	c.c.EndRequest(r.id)
 	return r, nil
 }
 


### PR DESCRIPTION
We discovered a problem in this library that causes the client to hang
indefinitely. This patch makes sure that the locking part
(`net.textproto.Pipeline.StopRequest`) is executed whenever the function
returns.

Steps to reproduce:

1. Establish a normal connection with `beanstalkd` and keep the connection open
2. Reserve a job through `TubeSet.Reserve(...)`
3. Exit the server
4. Reserve a job through `TubeSet.Reserve(...)`. The expected error is:
`reserve-with-timeout: read tcp srcip:srcport->dstip:dstport: read: connection
reset by peer`
5. Reserve a job through `TubeSet.Reserve(...)`. The expected error is:
`reserve-with-timeout: write tcp srcip:srcport->dstip:dstport: write: broken
pipe`

After step 3, `t.Conn.cmd(...)` (in `tubeset.go:30`) is executed without error,
because writes to a half-closed socket are accepted. Step 4, then, fails with
the error mentioned. In step 5, the write fails and `t.Conn.cmd(...)` returns
early in `conn.go:76`.

However, `c.c.StartRequest(r.id)` is not properly ended and this causes jobs
with an `id` larger than `r.id` to wait indefinitely to be processed.

Cc: @Minnozz
Fixes: #21