### PR TITLE
Fix example import path.

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -2,8 +2,9 @@ package beanstalk_test
 
 import (
 	"fmt"
-	"github.com/kr/beanstalk"
 	"time"
+
+	beanstalk "github.com/beanstalkd/go-beanstalk"
 )
 
 var conn, _ = beanstalk.Dial("tcp", "127.0.0.1:11300")


### PR DESCRIPTION
Importing `github.com/kr/beanstalk` in `example_test.go` will create indirect dependency for `github.com/beanstalkd/go-beanstalk`.

Rename  `github.com/kr/beanstalk` into `github.com/beanstalkd/go-beanstalk`.

please kindly review @kr @sergeyklay. 