### PR TITLE
return job id when buried

### DIFF
--- a/tube_test.go
+++ b/tube_test.go
@@ -20,6 +20,24 @@ func TestTubePut(t *testing.T) {
 	}
 }
 
+func TestTubePutBuried(t *testing.T) {
+	c := NewConn(mock("put 0 0 0 3\r\nfoo\r\n", "BURIED 7\r\n"))
+
+	id, err := c.Put([]byte("foo"), 0, 0, 0)
+	if err == nil {
+		t.Fatal("error expected")
+	}
+	if e, ok := err.(ConnError); !ok || e.Err != ErrBuried {
+		t.Fatal("expected ErrBuried, got", err)
+	}
+	if id != 7 {
+		t.Fatal("expected 7, got", id)
+	}
+	if err = c.Close(); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestTubePeekReady(t *testing.T) {
 	c := NewConn(mock("peek-ready\r\n", "FOUND 1 1\r\nx\r\n"))
 


### PR DESCRIPTION
After sending the command line and body, the client waits for a reply, which
may be:

 - `INSERTED <id>\r\n` to indicate success.

   - `<id>` is the integer id of the new job

 - `BURIED <id>\r\n` if the server ran out of memory trying to grow the
   priority queue data structure.

   - `<id>` is the integer id of the new job