### PR TITLE
Fixed deadlock-risky situation

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -74,6 +74,7 @@ func (c *Conn) Close() error {
 
 func (c *Conn) cmd(t *Tube, ts *TubeSet, body []byte, op string, args ...interface{}) (req, error) {
 	r := req{c.c.Next(), op}
+	defer c.c.EndRequest(r.id)
 	c.c.StartRequest(r.id)
 	err := c.adjustTubes(t, ts)
 	if err != nil {
@@ -91,7 +92,6 @@ func (c *Conn) cmd(t *Tube, ts *TubeSet, body []byte, op string, args ...interfa
 	if err != nil {
 		return req{}, ConnError{c, op, err}
 	}
-	c.c.EndRequest(r.id)
 	return r, nil
 }
 


### PR DESCRIPTION
Since EndRequest() is called only in the end of cmd(), it can be never called in case of return error.
So, there could be a deadlock if cmd stopped with error and was called for second time.

For example, if beanstalk server is unreachable for a while, it will be a deadlock.